### PR TITLE
Make generic implementations more poly-kinded

### DIFF
--- a/example/Record.hs
+++ b/example/Record.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE PolyKinds #-}
 module Main (
   main,
   Record (..),
@@ -48,8 +48,8 @@ instance FTraversable Cons where ftraverse = gftraverse
 -- Units
 -------------------------------------------------------------------------------
 
-data MyU1 (f :: Type -> Type) = MyU1 deriving Generic
-data MyV1 (f :: Type -> Type)        deriving Generic
+data MyU1 (f :: k -> Type) = MyU1 deriving Generic
+data MyV1 (f :: k -> Type)        deriving Generic
 
 instance FFunctor     MyU1 where ffmap     = ffmapDefault
 instance FFoldable    MyU1 where ffoldMap  = ffoldMapDefault

--- a/src/Data/Functor/Confusing.hs
+++ b/src/Data/Functor/Confusing.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP        #-}
+{-# LANGUAGE PolyKinds  #-}
 {-# LANGUAGE RankNTypes #-}
 -- |
 -- Csongor Kiss, Matthew Pickering, and Nicolas Wu. 2018. Generic deriving of generic traversals.

--- a/src/Data/HKD.hs
+++ b/src/Data/HKD.hs
@@ -538,7 +538,7 @@ instance FFoldable Limit where
 -- @
 
 gftraverse
-  :: forall t (f :: Type -> Type) (g :: Type -> Type) m. (Applicative m, Generic (t f), Generic (t g), GFTraversable (Curried (Yoneda m)) f g (Rep (t f)) (Rep (t g)))
+  :: forall t f g m. (Applicative m, Generic (t f), Generic (t g), GFTraversable (Curried (Yoneda m)) f g (Rep (t f)) (Rep (t g)))
   => (forall a. f a -> m (g a))
   -> t f
   -> m (t g)
@@ -615,7 +615,7 @@ instance (f ~ f', g ~ g', t ~ t', i ~ R, i' ~ R, Applicative m, FTraversable t) 
 -- @
 
 gfzipWith
-  :: forall t (f :: Type -> Type) (g :: Type -> Type) (h :: Type -> Type). (Generic (t f), Generic (t g), Generic (t h), GFZip f g h (Rep (t f)) (Rep (t g)) (Rep (t h)))
+  :: forall t f g h. (Generic (t f), Generic (t g), Generic (t h), GFZip f g h (Rep (t f)) (Rep (t g)) (Rep (t h)))
   => (forall a. f a -> g a -> h a)
   -> t f
   -> t g
@@ -665,7 +665,7 @@ instance (f ~ f', g ~ g', h ~ h', t0 ~ t1, t1 ~ t2, i0 ~ R, i1 ~ R, i2 ~ R, FZip
 -------------------------------------------------------------------------------
 
 gfrepeat
-  :: forall t (f :: Type -> Type). (Generic (t f), GFRepeat f (Rep (t f)))
+  :: forall t f. (Generic (t f), GFRepeat f (Rep (t f)))
   => (forall x. f x)
   -> t f
 gfrepeat x = to (gfrepeat0 x)


### PR DESCRIPTION
`gftraverse`, `gfzipWith`, and `gfrepeat` all monomorphize the kinds of type variables (e.g., `f` and `g`) to `Type -> Type`, but this can be generalized to `k -> Type` quite straightforwardly. I've modified one of the examples to ensure that this generalization actually does happen.

In order to preserve the existing order of type applications in these functions, I opted not to explicitly quantify the kind variable `k`.